### PR TITLE
BUG FIX

### DIFF
--- a/chap07/app.py
+++ b/chap07/app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from flask import Flask, render_template
 from redis import Redis
 import os,random


### PR DESCRIPTION
When `docker-compose up` operate, 
`[Errno 8] Exec format error: '/opt/imageview/app.py' Occured
So I add shebang to top of the code

Env
Windows 10 Education (Korean)
docker version: 18.09.2, build 6247962
docker-compose version: 1.23.1, build 1110ad01


reference:
https://stackoverflow.com/questions/55271912/flask-cli-throws-oserror-errno-8-exec-format-error-when-run-through-docker